### PR TITLE
[DO NOT MERGE] Use rb_ary_modify_check only when called with block

### DIFF
--- a/array.c
+++ b/array.c
@@ -4435,8 +4435,10 @@ rb_ary_uniq_bang(VALUE ary)
     rb_ary_modify_check(ary);
     if (RARRAY_LEN(ary) <= 1)
         return Qnil;
-    if (rb_block_given_p())
+    if (rb_block_given_p()) {
 	hash = ary_make_hash_by(ary);
+	rb_ary_modify_check(ary);
+    }
     else
 	hash = ary_make_hash(ary);
 
@@ -4444,7 +4446,6 @@ rb_ary_uniq_bang(VALUE ary)
     if (RARRAY_LEN(ary) == hash_size) {
 	return Qnil;
     }
-    rb_ary_modify_check(ary);
     ARY_SET_LEN(ary, 0);
     if (ARY_SHARED_P(ary) && !ARY_EMBED_P(ary)) {
 	rb_ary_unshare(ary);


### PR DESCRIPTION
This patch will change the behavior of `uniq!`, with these code.

```ruby
arr = [1, 2]
p arr.uniq! { |e| arr.freeze; e }
puts '1, 2 uniq! -> ok'
```

```
$ ./miniruby tmp/test_uniq.rb
Traceback (most recent call last):
        1: from tmp/test_uniq.rb:2:in `<main>'
tmp/test_uniq.rb:2:in `uniq!': can't modify frozen Array (RuntimeError)
```


```
~/.g/g/h/ruby ❯❯❯ ruby -v
ruby 2.4.2p198 (2017-09-14 revision 59899) [x86_64-darwin16]
~/.g/g/h/ruby ❯❯❯ ruby tmp/test_uniq.rb
nil
1, 2 uniq! -> ok
```